### PR TITLE
Serialize and rate-limit requests to the generator

### DIFF
--- a/custom_components/cummins_generator/__init__.py
+++ b/custom_components/cummins_generator/__init__.py
@@ -1,35 +1,55 @@
 """Cummins Generator integration."""
-import aiohttp
-import base64
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.const import CONF_HOST
+from .client import GeneratorClient
 from .sensor import CumminsGeneratorCoordinator
 
 DOMAIN = "cummins_generator"
+PLATFORMS = ["sensor", "button", "binary_sensor", "select", "datetime"]
+
+CONF_MIN_REQUEST_GAP_MS = "min_request_gap_ms"
+DEFAULT_MIN_REQUEST_GAP_MS = 500
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Cummins Generator from a config entry."""
     host = entry.data[CONF_HOST]
     password = entry.data.get("password", "cummins")
-    
-    # Create shared coordinator
-    coordinator = CumminsGeneratorCoordinator(hass, host, password)
-    
-    # Test connectivity
+    min_gap_ms = entry.options.get(CONF_MIN_REQUEST_GAP_MS, DEFAULT_MIN_REQUEST_GAP_MS)
+
+    client = GeneratorClient(hass, host, password, min_gap_ms)
+    coordinator = CumminsGeneratorCoordinator(hass, client)
+
     try:
         await coordinator.async_config_entry_first_refresh()
     except Exception as err:
+        await client.close()
         raise ConfigEntryNotReady(f"Cannot connect to generator: {err}")
-    
-    # Store coordinator for platforms to use
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
-    
-    await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "button", "binary_sensor", "select", "datetime"])
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "client": client,
+        "coordinator": coordinator,
+    }
+
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Apply options changes without a full reload."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    data["client"].update_min_gap(
+        entry.options.get(CONF_MIN_REQUEST_GAP_MS, DEFAULT_MIN_REQUEST_GAP_MS)
+    )
+
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    hass.data[DOMAIN].pop(entry.entry_id)
-    return await hass.config_entries.async_unload_platforms(entry, ["sensor", "button", "binary_sensor", "select", "datetime"])
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    data = hass.data[DOMAIN].pop(entry.entry_id)
+    await data["client"].close()
+    return unload_ok

--- a/custom_components/cummins_generator/__init__.py
+++ b/custom_components/cummins_generator/__init__.py
@@ -4,13 +4,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.const import CONF_HOST
 from .client import GeneratorClient
+from .const import CONF_MIN_REQUEST_GAP_MS, DEFAULT_MIN_REQUEST_GAP_MS
 from .sensor import CumminsGeneratorCoordinator
 
 DOMAIN = "cummins_generator"
 PLATFORMS = ["sensor", "button", "binary_sensor", "select", "datetime"]
-
-CONF_MIN_REQUEST_GAP_MS = "min_request_gap_ms"
-DEFAULT_MIN_REQUEST_GAP_MS = 500
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/cummins_generator/binary_sensor.py
+++ b/custom_components/cummins_generator/binary_sensor.py
@@ -1,14 +1,12 @@
 """Cummins Generator binary sensor platform."""
 from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
-from homeassistant.const import CONF_HOST
 from homeassistant.helpers.entity import DeviceInfo
-from .sensor import CumminsGeneratorCoordinator
 
 DOMAIN = "cummins_generator"
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Cummins Generator binary sensors."""
-    coordinator = hass.data["cummins_generator"][config_entry.entry_id]
+    coordinator = hass.data["cummins_generator"][config_entry.entry_id]["coordinator"]
     
     binary_sensors = [
         CumminsGeneratorBinarySensor(coordinator, "utility_present", "Utility Present", 0x01),

--- a/custom_components/cummins_generator/button.py
+++ b/custom_components/cummins_generator/button.py
@@ -1,42 +1,38 @@
 """Cummins Generator button platform."""
-import aiohttp
-import base64
 import logging
 from homeassistant.components.button import ButtonEntity
-from homeassistant.const import CONF_HOST
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = "cummins_generator"
 
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Cummins Generator buttons."""
-    host = config_entry.data[CONF_HOST]
-    password = config_entry.data.get("password", "cummins")
-    auth = base64.b64encode(f"admin:{password}".encode()).decode("ascii")
-    
+    client = hass.data[DOMAIN][config_entry.entry_id]["client"]
+
     buttons = [
-        CumminsGeneratorButton(host, auth, "start", "Start Genset", "@242=2"),
-        CumminsGeneratorButton(host, auth, "stop", "Stop Genset", "@242=1"),
-        CumminsGeneratorButton(host, auth, "enable_standby", "Enable Standby", "@385=1"),
-        CumminsGeneratorButton(host, auth, "disable_standby", "Disable Standby", "@385=0"),
-        CumminsGeneratorButton(host, auth, "exercise_now", "Exercise Now", "@242=3"),
-        CumminsGeneratorSyncTimeButton(host, auth),
+        CumminsGeneratorButton(client, "start", "Start Genset", "@242=2"),
+        CumminsGeneratorButton(client, "stop", "Stop Genset", "@242=1"),
+        CumminsGeneratorButton(client, "enable_standby", "Enable Standby", "@385=1"),
+        CumminsGeneratorButton(client, "disable_standby", "Disable Standby", "@385=0"),
+        CumminsGeneratorButton(client, "exercise_now", "Exercise Now", "@242=3"),
+        CumminsGeneratorSyncTimeButton(client),
     ]
     async_add_entities(buttons)
+
 
 class CumminsGeneratorButton(ButtonEntity):
     """Representation of a Cummins Generator button."""
 
-    def __init__(self, host, auth, button_type, name, parameter):
+    def __init__(self, client, button_type, name, parameter):
         """Initialize the button."""
-        self.host = host
-        self.auth = auth
+        self.client = client
         self.button_type = button_type
         self._name = name
         self.parameter = parameter
-        self._attr_unique_id = f"{host}_{button_type}"
+        self._attr_unique_id = f"{client.host}_{button_type}"
 
     @property
     def name(self):
@@ -47,7 +43,7 @@ class CumminsGeneratorButton(ButtonEntity):
     def device_info(self):
         """Return device information."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self.host)},
+            identifiers={(DOMAIN, self.client.host)},
             name="Cummins Generator",
             manufacturer="Cummins",
             model="Generator",
@@ -56,23 +52,17 @@ class CumminsGeneratorButton(ButtonEntity):
     async def async_press(self):
         """Handle the button press."""
         try:
-            async with aiohttp.ClientSession() as session:
-                headers = {"Authorization": f"Basic {self.auth}"}
-                url = f"http://{self.host}/wr_logical.cgi?{self.parameter}"
-                async with session.get(url, headers=headers) as response:
-                    if response.status != 200:
-                        _LOGGER.error(f"Failed to execute {self._name}: {response.status}")
+            await self.client.get(f"/wr_logical.cgi?{self.parameter}")
         except Exception as err:
-            _LOGGER.error(f"Error executing {self._name}: {err}")
+            _LOGGER.error("Error executing %s: %s", self._name, err)
 
 
 class CumminsGeneratorSyncTimeButton(ButtonEntity):
     """Button to sync generator time to HA clock."""
 
-    def __init__(self, host, auth):
-        self.host = host
-        self.auth = auth
-        self._attr_unique_id = f"{host}_sync_time"
+    def __init__(self, client):
+        self.client = client
+        self._attr_unique_id = f"{client.host}_sync_time"
 
     @property
     def name(self):
@@ -81,7 +71,7 @@ class CumminsGeneratorSyncTimeButton(ButtonEntity):
     @property
     def device_info(self):
         return DeviceInfo(
-            identifiers={(DOMAIN, self.host)},
+            identifiers={(DOMAIN, self.client.host)},
             name="Cummins Generator",
             manufacturer="Cummins",
             model="Generator",
@@ -91,10 +81,6 @@ class CumminsGeneratorSyncTimeButton(ButtonEntity):
         now = dt_util.now()
         params = f"@448={now.month}&@449={now.day}&@450={now.year}&@402={now.hour}&@403={now.minute}"
         try:
-            async with aiohttp.ClientSession() as session:
-                headers = {"Authorization": f"Basic {self.auth}"}
-                async with session.get(f"http://{self.host}/wr_logical.cgi?{params}", headers=headers) as resp:
-                    if resp.status != 200:
-                        _LOGGER.error("Failed to sync time: %s", resp.status)
+            await self.client.get(f"/wr_logical.cgi?{params}")
         except Exception as err:
             _LOGGER.error("Error syncing time: %s", err)

--- a/custom_components/cummins_generator/client.py
+++ b/custom_components/cummins_generator/client.py
@@ -1,0 +1,72 @@
+"""Rate-limited HTTP client for the Cummins generator.
+
+The generator's embedded controller has a flakey network stack and locks
+up under concurrent requests. Every request from every platform must go
+through a single shared instance of this client so we can serialize
+them and enforce a minimum gap between requests.
+"""
+import asyncio
+import base64
+import logging
+import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT_SECONDS = 10
+
+
+class GeneratorClient:
+    """Serialized, rate-limited HTTP client for one generator."""
+
+    def __init__(self, hass, host, password, min_gap_ms):
+        self._hass = hass
+        self.host = host
+        self._auth_header = "Basic " + base64.b64encode(
+            f"admin:{password}".encode()
+        ).decode("ascii")
+        self._min_gap = max(0, min_gap_ms) / 1000.0
+        self._lock = asyncio.Lock()
+        self._session: aiohttp.ClientSession | None = None
+        self._last_request_end = 0.0
+
+    def update_min_gap(self, min_gap_ms):
+        """Change the minimum inter-request gap live."""
+        self._min_gap = max(0, min_gap_ms) / 1000.0
+
+    async def get(self, path: str) -> str:
+        """Issue a serialized, rate-limited GET and return the body text."""
+        headers = {"Authorization": self._auth_header}
+        timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT_SECONDS)
+        url = f"http://{self.host}{path}"
+
+        async with self._lock:
+            if self._session is None:
+                self._session = aiohttp.ClientSession()
+
+            now = self._hass.loop.time()
+            wait = self._min_gap - (now - self._last_request_end)
+            if wait > 0:
+                _LOGGER.debug("Sleeping %.3fs before %s", wait, path)
+                await asyncio.sleep(wait)
+
+            try:
+                async with self._session.get(
+                    url, headers=headers, timeout=timeout
+                ) as response:
+                    if response.status != 200:
+                        raise aiohttp.ClientResponseError(
+                            response.request_info,
+                            response.history,
+                            status=response.status,
+                            message=f"HTTP {response.status} for {path}",
+                            headers=response.headers,
+                        )
+                    return await response.text()
+            finally:
+                self._last_request_end = self._hass.loop.time()
+
+    async def close(self):
+        """Close the underlying aiohttp session."""
+        if self._session is not None:
+            await self._session.close()
+            self._session = None

--- a/custom_components/cummins_generator/config_flow.py
+++ b/custom_components/cummins_generator/config_flow.py
@@ -29,14 +29,11 @@ class CumminsGeneratorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        return CumminsGeneratorOptionsFlow(config_entry)
+        return CumminsGeneratorOptionsFlow()
 
 
 class CumminsGeneratorOptionsFlow(config_entries.OptionsFlow):
     """Options flow for Cummins Generator."""
-
-    def __init__(self, config_entry):
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:

--- a/custom_components/cummins_generator/config_flow.py
+++ b/custom_components/cummins_generator/config_flow.py
@@ -1,9 +1,14 @@
 """Config flow for Cummins Generator integration."""
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.core import callback
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 
 DOMAIN = "cummins_generator"
+
+CONF_MIN_REQUEST_GAP_MS = "min_request_gap_ms"
+DEFAULT_MIN_REQUEST_GAP_MS = 500
+
 
 class CumminsGeneratorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Cummins Generator."""
@@ -19,4 +24,32 @@ class CumminsGeneratorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_HOST): str,
                 vol.Required(CONF_PASSWORD, default="cummins"): str,
             })
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        return CumminsGeneratorOptionsFlow(config_entry)
+
+
+class CumminsGeneratorOptionsFlow(config_entries.OptionsFlow):
+    """Options flow for Cummins Generator."""
+
+    def __init__(self, config_entry):
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current = self.config_entry.options.get(
+            CONF_MIN_REQUEST_GAP_MS, DEFAULT_MIN_REQUEST_GAP_MS
+        )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({
+                vol.Required(CONF_MIN_REQUEST_GAP_MS, default=current): vol.All(
+                    vol.Coerce(int), vol.Range(min=0, max=10000)
+                ),
+            }),
         )

--- a/custom_components/cummins_generator/config_flow.py
+++ b/custom_components/cummins_generator/config_flow.py
@@ -4,10 +4,9 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 
-DOMAIN = "cummins_generator"
+from .const import CONF_MIN_REQUEST_GAP_MS, DEFAULT_MIN_REQUEST_GAP_MS
 
-CONF_MIN_REQUEST_GAP_MS = "min_request_gap_ms"
-DEFAULT_MIN_REQUEST_GAP_MS = 500
+DOMAIN = "cummins_generator"
 
 
 class CumminsGeneratorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/cummins_generator/const.py
+++ b/custom_components/cummins_generator/const.py
@@ -1,0 +1,4 @@
+"""Constants for the Cummins Generator integration."""
+
+CONF_MIN_REQUEST_GAP_MS = "min_request_gap_ms"
+DEFAULT_MIN_REQUEST_GAP_MS = 50

--- a/custom_components/cummins_generator/const.py
+++ b/custom_components/cummins_generator/const.py
@@ -1,4 +1,4 @@
 """Constants for the Cummins Generator integration."""
 
 CONF_MIN_REQUEST_GAP_MS = "min_request_gap_ms"
-DEFAULT_MIN_REQUEST_GAP_MS = 50
+DEFAULT_MIN_REQUEST_GAP_MS = 500

--- a/custom_components/cummins_generator/datetime.py
+++ b/custom_components/cummins_generator/datetime.py
@@ -1,10 +1,8 @@
 """Cummins Generator datetime platform."""
 import re
-import aiohttp
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from homeassistant.components.datetime import DateTimeEntity
-from homeassistant.const import CONF_HOST
 from homeassistant.util import dt as dt_util
 from homeassistant.helpers.entity import DeviceInfo
 
@@ -14,17 +12,18 @@ DOMAIN = "cummins_generator"
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Cummins Generator datetime entity."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    async_add_entities([CumminsGeneratorDateTime(coordinator)])
+    data = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities([CumminsGeneratorDateTime(data["coordinator"], data["client"])])
 
 
 class CumminsGeneratorDateTime(DateTimeEntity):
     """DateTime entity for Cummins Generator time/date."""
 
-    def __init__(self, coordinator):
+    def __init__(self, coordinator, client):
         """Initialize the datetime entity."""
         self.coordinator = coordinator
-        self._attr_unique_id = f"{coordinator.host}_datetime"
+        self.client = client
+        self._attr_unique_id = f"{client.host}_datetime"
         self._attr_has_date = True
         self._attr_has_time = True
         self._value = None
@@ -36,7 +35,7 @@ class CumminsGeneratorDateTime(DateTimeEntity):
     @property
     def device_info(self):
         return DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.host)},
+            identifiers={(DOMAIN, self.client.host)},
             name="Cummins Generator",
             manufacturer="Cummins",
             model="Generator",
@@ -49,14 +48,8 @@ class CumminsGeneratorDateTime(DateTimeEntity):
     async def async_update(self):
         """Fetch current date/time from generator."""
         try:
-            async with aiohttp.ClientSession() as session:
-                headers = {"Authorization": f"Basic {self.coordinator.auth}"}
-                async with session.get(
-                    f"http://{self.coordinator.host}/timedate.html", headers=headers
-                ) as response:
-                    if response.status == 200:
-                        html = await response.text()
-                        self._value = self._parse_datetime(html)
+            html = await self.client.get("/timedate.html")
+            self._value = self._parse_datetime(html)
         except Exception as err:
             _LOGGER.error("Error fetching generator time: %s", err)
 
@@ -93,14 +86,8 @@ class CumminsGeneratorDateTime(DateTimeEntity):
             f"&@402={local.hour}&@403={local.minute}"
         )
         try:
-            async with aiohttp.ClientSession() as session:
-                headers = {"Authorization": f"Basic {self.coordinator.auth}"}
-                url = f"http://{self.coordinator.host}/wr_logical.cgi?{params}"
-                async with session.get(url, headers=headers) as response:
-                    if response.status != 200:
-                        _LOGGER.error("Failed to set date/time: %s", response.status)
-                    else:
-                        self._value = value.replace(second=0, microsecond=0)
-                        self.async_write_ha_state()
+            await self.client.get(f"/wr_logical.cgi?{params}")
+            self._value = value.replace(second=0, microsecond=0)
+            self.async_write_ha_state()
         except Exception as err:
             _LOGGER.error("Error setting date/time: %s", err)

--- a/custom_components/cummins_generator/select.py
+++ b/custom_components/cummins_generator/select.py
@@ -1,9 +1,6 @@
 """Cummins Generator select platform."""
-import aiohttp
-import base64
 import logging
 from homeassistant.components.select import SelectEntity
-from homeassistant.const import CONF_HOST
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from datetime import timedelta
@@ -14,9 +11,8 @@ SCAN_INTERVAL = timedelta(seconds=30)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Cummins Generator select entities."""
-    host = config_entry.data[CONF_HOST]
-    password = config_entry.data.get("password", "cummins")
-    coordinator = CumminsLoadCoordinator(hass, host, password)
+    client = hass.data[DOMAIN][config_entry.entry_id]["client"]
+    coordinator = CumminsLoadCoordinator(hass, client)
     await coordinator.async_config_entry_first_refresh()
     
     selects = [
@@ -33,45 +29,31 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class CumminsLoadCoordinator(DataUpdateCoordinator):
     """Data coordinator for Cummins Generator load management."""
 
-    def __init__(self, hass, host, password):
+    def __init__(self, hass, client):
         """Initialize the coordinator."""
         super().__init__(hass, _LOGGER, name="Cummins Load", update_interval=SCAN_INTERVAL)
-        self.host = host
-        self.auth = base64.b64encode(f"admin:{password}".encode()).decode("ascii")
+        self.client = client
+        self.host = client.host
 
     async def _async_update_data(self):
         """Fetch load data from the generator."""
         try:
-            async with aiohttp.ClientSession() as session:
-                headers = {"Authorization": f"Basic {self.auth}"}
-                
-                # Get load data from loads.html
-                load_data = {}
-                async with session.get(f"http://{self.host}/loads.html", headers=headers) as response:
-                    if response.status == 200:
-                        html = await response.text()
-                        load_data = self._parse_loads_html(html)
-                
-                # Get load status from loads_data.html
-                async with session.get(f"http://{self.host}/loads_data.html", headers=headers) as response:
-                    if response.status == 200:
-                        data = await response.text()
-                        lines = data.strip().split('\n')
-                        if len(lines) >= 3:
-                            load_data.update({
-                                "load_1": "Connected" if int(lines[1]) == 0 else "Disconnected",
-                                "load_2": "Connected" if int(lines[2]) == 0 else "Disconnected",
-                            })
-                
-                # Get exercise data
-                exercise_data = {}
-                async with session.get(f"http://{self.host}/exercise.html", headers=headers) as response:
-                    if response.status == 200:
-                        html = await response.text()
-                        exercise_data = self._parse_exercise_html(html)
-                
-                return {**load_data, **exercise_data}
-                
+            load_html = await self.client.get("/loads.html")
+            load_data = self._parse_loads_html(load_html)
+
+            loads_data = await self.client.get("/loads_data.html")
+            lines = loads_data.strip().split('\n')
+            if len(lines) >= 3:
+                load_data.update({
+                    "load_1": "Connected" if int(lines[1]) == 0 else "Disconnected",
+                    "load_2": "Connected" if int(lines[2]) == 0 else "Disconnected",
+                })
+
+            exercise_html = await self.client.get("/exercise.html")
+            exercise_data = self._parse_exercise_html(exercise_html)
+
+            return {**load_data, **exercise_data}
+
         except Exception as err:
             raise UpdateFailed(f"Error communicating with generator: {err}")
 
@@ -160,37 +142,33 @@ class CumminsGeneratorSelect(SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
+        if self.select_type == "load_mode":
+            value = "1" if option == "Manual" else "2"
+            path = f"/wr_logical.cgi?@426={value}"
+        elif self.select_type == "load_1":
+            value = "3" if option == "Disconnected" else "4"
+            path = f"/wr_logical.cgi?@426={value}"
+        elif self.select_type == "load_2":
+            value = "5" if option == "Disconnected" else "6"
+            path = f"/wr_logical.cgi?@426={value}"
+        elif self.select_type == "exercise_frequency":
+            value = ["0", "1", "2", "3"][["Never", "Weekly", "Bimonthly", "Monthly"].index(option)]
+            path = f"/wr_logical.cgi?@425={value}"
+        elif self.select_type == "exercise_day":
+            value = str(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"].index(option))
+            path = f"/wr_logical.cgi?@391={value}"
+        elif self.select_type == "exercise_hour":
+            path = f"/wr_logical.cgi?@392={option}"
+        elif self.select_type == "exercise_minute":
+            path = f"/wr_logical.cgi?@393={option}"
+        else:
+            return
+
         try:
-            async with aiohttp.ClientSession() as session:
-                headers = {"Authorization": f"Basic {self.coordinator.auth}"}
-                
-                if self.select_type == "load_mode":
-                    value = "1" if option == "Manual" else "2"
-                    url = f"http://{self.coordinator.host}/wr_logical.cgi?@426={value}"
-                elif self.select_type == "load_1":
-                    value = "3" if option == "Disconnected" else "4"
-                    url = f"http://{self.coordinator.host}/wr_logical.cgi?@426={value}"
-                elif self.select_type == "load_2":
-                    value = "5" if option == "Disconnected" else "6"
-                    url = f"http://{self.coordinator.host}/wr_logical.cgi?@426={value}"
-                elif self.select_type == "exercise_frequency":
-                    value = ["0", "1", "2", "3"][["Never", "Weekly", "Bimonthly", "Monthly"].index(option)]
-                    url = f"http://{self.coordinator.host}/wr_logical.cgi?@425={value}"
-                elif self.select_type == "exercise_day":
-                    value = str(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"].index(option))
-                    url = f"http://{self.coordinator.host}/wr_logical.cgi?@391={value}"
-                elif self.select_type == "exercise_hour":
-                    url = f"http://{self.coordinator.host}/wr_logical.cgi?@392={option}"
-                elif self.select_type == "exercise_minute":
-                    url = f"http://{self.coordinator.host}/wr_logical.cgi?@393={option}"
-                
-                async with session.get(url, headers=headers) as response:
-                    if response.status != 200:
-                        _LOGGER.error(f"Failed to set {self._name}: {response.status}")
-                    else:
-                        await self.coordinator.async_request_refresh()
+            await self.coordinator.client.get(path)
+            await self.coordinator.async_request_refresh()
         except Exception as err:
-            _LOGGER.error(f"Error setting {self._name}: {err}")
+            _LOGGER.error("Error setting %s: %s", self._name, err)
 
     async def async_update(self):
         """Update the entity."""

--- a/custom_components/cummins_generator/sensor.py
+++ b/custom_components/cummins_generator/sensor.py
@@ -1,11 +1,7 @@
 """Cummins Generator sensor platform."""
-import asyncio
-import aiohttp
-import base64
 import logging
 from datetime import timedelta
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
-from homeassistant.const import CONF_HOST
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.entity import DeviceInfo
 
@@ -15,8 +11,8 @@ DOMAIN = "cummins_generator"
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Cummins Generator sensors."""
-    coordinator = hass.data["cummins_generator"][config_entry.entry_id]
-    
+    coordinator = hass.data["cummins_generator"][config_entry.entry_id]["coordinator"]
+
     sensors = [
         CumminsGeneratorSensor(coordinator, "status", "Status"),
         CumminsGeneratorSensor(coordinator, "battery_voltage", "Battery Voltage", "V"),
@@ -31,23 +27,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class CumminsGeneratorCoordinator(DataUpdateCoordinator):
     """Data coordinator for Cummins Generator."""
 
-    def __init__(self, hass, host, password):
+    def __init__(self, hass, client):
         """Initialize the coordinator."""
         super().__init__(hass, _LOGGER, name="Cummins Generator", update_interval=SCAN_INTERVAL)
-        self.host = host
-        self.auth = base64.b64encode(f"admin:{password}".encode()).decode("ascii")
+        self.client = client
+        self.host = client.host
 
     async def _async_update_data(self):
         """Fetch data from the generator."""
         try:
-            async with aiohttp.ClientSession() as session:
-                headers = {"Authorization": f"Basic {self.auth}"}
-                async with session.get(f"http://{self.host}/index_data.html", headers=headers) as response:
-                    if response.status == 200:
-                        data = await response.text()
-                        return self._parse_data(data)
-                    else:
-                        raise UpdateFailed(f"Error fetching data: {response.status}")
+            data = await self.client.get("/index_data.html")
+            return self._parse_data(data)
         except Exception as err:
             raise UpdateFailed(f"Error communicating with generator: {err}")
 

--- a/custom_components/cummins_generator/strings.json
+++ b/custom_components/cummins_generator/strings.json
@@ -18,5 +18,16 @@
     "abort": {
       "already_configured": "Generator is already configured"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Cummins Generator options",
+        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; this setting adds a minimum delay between them.",
+        "data": {
+          "min_request_gap_ms": "Minimum delay between requests (ms)"
+        }
+      }
+    }
   }
 }

--- a/custom_components/cummins_generator/strings.json
+++ b/custom_components/cummins_generator/strings.json
@@ -23,9 +23,9 @@
     "step": {
       "init": {
         "title": "Cummins Generator options",
-        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; this setting adds a minimum delay between them.",
+        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; this setting adds a minimum delay between them. The default of 50 ms is usually enough; increase it if the controller still becomes unresponsive.",
         "data": {
-          "min_request_gap_ms": "Minimum delay between requests (ms)"
+          "min_request_gap_ms": "Minimum delay between requests (ms, default 50)"
         }
       }
     }

--- a/custom_components/cummins_generator/strings.json
+++ b/custom_components/cummins_generator/strings.json
@@ -23,9 +23,9 @@
     "step": {
       "init": {
         "title": "Cummins Generator options",
-        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; this setting adds a minimum delay between them. The default of 50 ms is usually enough; increase it if the controller still becomes unresponsive.",
+        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; this setting adds a minimum delay between them.",
         "data": {
-          "min_request_gap_ms": "Minimum delay between requests (ms, default 50)"
+          "min_request_gap_ms": "Minimum delay between requests (ms, default 500)"
         }
       }
     }

--- a/custom_components/cummins_generator/translations/en.json
+++ b/custom_components/cummins_generator/translations/en.json
@@ -18,5 +18,16 @@
     "abort": {
       "already_configured": "Generator is already configured"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Cummins Generator options",
+        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; this setting adds a minimum delay between them.",
+        "data": {
+          "min_request_gap_ms": "Minimum delay between requests (ms)"
+        }
+      }
+    }
   }
 }

--- a/custom_components/cummins_generator/translations/en.json
+++ b/custom_components/cummins_generator/translations/en.json
@@ -23,9 +23,9 @@
     "step": {
       "init": {
         "title": "Cummins Generator options",
-        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; this setting adds a minimum delay between them.",
+        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; this setting adds a minimum delay between them. The default of 50 ms is usually enough; increase it if the controller still becomes unresponsive.",
         "data": {
-          "min_request_gap_ms": "Minimum delay between requests (ms)"
+          "min_request_gap_ms": "Minimum delay between requests (ms, default 50)"
         }
       }
     }

--- a/custom_components/cummins_generator/translations/en.json
+++ b/custom_components/cummins_generator/translations/en.json
@@ -23,9 +23,9 @@
     "step": {
       "init": {
         "title": "Cummins Generator options",
-        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; this setting adds a minimum delay between them. The default of 50 ms is usually enough; increase it if the controller still becomes unresponsive.",
+        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; this setting adds a minimum delay between them.",
         "data": {
-          "min_request_gap_ms": "Minimum delay between requests (ms, default 50)"
+          "min_request_gap_ms": "Minimum delay between requests (ms, default 500)"
         }
       }
     }


### PR DESCRIPTION
## Summary

The generator's embedded web server has a flakey network stack and locks up under concurrent requests. Today the integration fires HTTP requests at it with no coordination — two independent `DataUpdateCoordinator`s poll on the same 30-second cadence, buttons/selects/datetime each open their own `aiohttp.ClientSession`, and setup produces up to four near-simultaneous requests. Once the controller wedges, recovery requires an out-of-band IP flip on the front panel.

This PR routes every HTTP request from every platform through a single shared `GeneratorClient` per config entry that:

- owns one persistent `aiohttp.ClientSession` (reused across all requests)
- serializes requests behind an `asyncio.Lock` (max 1 in flight)
- enforces a minimum gap between requests (default 500 ms, configurable via a new options flow)
- applies a 10 s per-request timeout so a hung controller can't wedge the serialization lock forever

Fixes #16.

## Test plan

- [x] Restart HA with the integration installed; confirm no `UpdateFailed` or timeout errors during first refresh.
- [x] Enable `logger: custom_components.cummins_generator: debug` and confirm request-gap logging shows serialized calls ~500 ms apart at startup.
- [x] Leave HA running for 10+ minutes and verify the 30-second polling cycles stay healthy and the generator remains responsive.
- [ ] Press Start/Stop buttons during an active poll and confirm they queue behind the poll rather than racing.
- [x] Open **Settings → Devices & Services → Cummins Generator → Configure**, change the minimum request gap, and confirm the new spacing takes effect without a full HA restart.