### PR TITLE
Allow editing the password after initial setup

### DIFF
--- a/custom_components/cummins_generator/__init__.py
+++ b/custom_components/cummins_generator/__init__.py
@@ -43,6 +43,7 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     data["client"].update_min_gap(
         entry.options.get(CONF_MIN_REQUEST_GAP_MS, DEFAULT_MIN_REQUEST_GAP_MS)
     )
+    data["client"].update_password(entry.data.get("password", "cummins"))
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/cummins_generator/client.py
+++ b/custom_components/cummins_generator/client.py
@@ -33,6 +33,12 @@ class GeneratorClient:
         """Change the minimum inter-request gap live."""
         self._min_gap = max(0, min_gap_ms) / 1000.0
 
+    def update_password(self, password):
+        """Change the admin password live."""
+        self._auth_header = "Basic " + base64.b64encode(
+            f"admin:{password}".encode()
+        ).decode("ascii")
+
     async def get(self, path: str) -> str:
         """Issue a serialized, rate-limited GET and return the body text."""
         headers = {"Authorization": self._auth_header}

--- a/custom_components/cummins_generator/client.py
+++ b/custom_components/cummins_generator/client.py
@@ -10,9 +10,42 @@ import base64
 import logging
 import aiohttp
 
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
 _LOGGER = logging.getLogger(__name__)
 
 REQUEST_TIMEOUT_SECONDS = 10
+
+
+class InvalidAuth(Exception):
+    """Generator rejected the supplied password."""
+
+
+class CannotConnect(Exception):
+    """Could not reach the generator."""
+
+
+async def validate_credentials(hass, host: str, password: str) -> None:
+    """Probe the generator with the given credentials.
+
+    Raises InvalidAuth on 401 or CannotConnect on any other failure.
+    """
+    session = async_get_clientsession(hass)
+    auth_header = "Basic " + base64.b64encode(
+        f"admin:{password}".encode()
+    ).decode("ascii")
+    url = f"http://{host}/index_data.html"
+    timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT_SECONDS)
+    try:
+        async with session.get(
+            url, headers={"Authorization": auth_header}, timeout=timeout
+        ) as response:
+            if response.status == 401:
+                raise InvalidAuth
+            if response.status != 200:
+                raise CannotConnect(f"HTTP {response.status}")
+    except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+        raise CannotConnect(str(err)) from err
 
 
 class GeneratorClient:

--- a/custom_components/cummins_generator/config_flow.py
+++ b/custom_components/cummins_generator/config_flow.py
@@ -36,15 +36,23 @@ class CumminsGeneratorOptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:
+            new_password = user_input.pop(CONF_PASSWORD)
+            if new_password != self.config_entry.data.get(CONF_PASSWORD):
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data={**self.config_entry.data, CONF_PASSWORD: new_password},
+                )
             return self.async_create_entry(title="", data=user_input)
 
-        current = self.config_entry.options.get(
+        current_gap = self.config_entry.options.get(
             CONF_MIN_REQUEST_GAP_MS, DEFAULT_MIN_REQUEST_GAP_MS
         )
+        current_password = self.config_entry.data.get(CONF_PASSWORD, "cummins")
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema({
-                vol.Required(CONF_MIN_REQUEST_GAP_MS, default=current): vol.All(
+                vol.Required(CONF_PASSWORD, default=current_password): str,
+                vol.Required(CONF_MIN_REQUEST_GAP_MS, default=current_gap): vol.All(
                     vol.Coerce(int), vol.Range(min=0, max=10000)
                 ),
             }),

--- a/custom_components/cummins_generator/config_flow.py
+++ b/custom_components/cummins_generator/config_flow.py
@@ -4,6 +4,7 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 
+from .client import CannotConnect, InvalidAuth, validate_credentials
 from .const import CONF_MIN_REQUEST_GAP_MS, DEFAULT_MIN_REQUEST_GAP_MS
 
 DOMAIN = "cummins_generator"
@@ -14,15 +15,28 @@ class CumminsGeneratorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
+        errors: dict[str, str] = {}
         if user_input is not None:
-            return self.async_create_entry(title="Cummins Generator", data=user_input)
+            try:
+                await validate_credentials(
+                    self.hass, user_input[CONF_HOST], user_input[CONF_PASSWORD]
+                )
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(
+                    title="Cummins Generator", data=user_input
+                )
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema({
                 vol.Required(CONF_HOST): str,
                 vol.Required(CONF_PASSWORD, default="cummins"): str,
-            })
+            }),
+            errors=errors,
         )
 
     @staticmethod
@@ -35,14 +49,27 @@ class CumminsGeneratorOptionsFlow(config_entries.OptionsFlow):
     """Options flow for Cummins Generator."""
 
     async def async_step_init(self, user_input=None):
+        errors: dict[str, str] = {}
         if user_input is not None:
             new_password = user_input.pop(CONF_PASSWORD)
             if new_password != self.config_entry.data.get(CONF_PASSWORD):
-                self.hass.config_entries.async_update_entry(
-                    self.config_entry,
-                    data={**self.config_entry.data, CONF_PASSWORD: new_password},
-                )
-            return self.async_create_entry(title="", data=user_input)
+                try:
+                    await validate_credentials(
+                        self.hass,
+                        self.config_entry.data[CONF_HOST],
+                        new_password,
+                    )
+                except InvalidAuth:
+                    errors["base"] = "invalid_auth"
+                except CannotConnect:
+                    errors["base"] = "cannot_connect"
+                else:
+                    self.hass.config_entries.async_update_entry(
+                        self.config_entry,
+                        data={**self.config_entry.data, CONF_PASSWORD: new_password},
+                    )
+            if not errors:
+                return self.async_create_entry(title="", data=user_input)
 
         current_gap = self.config_entry.options.get(
             CONF_MIN_REQUEST_GAP_MS, DEFAULT_MIN_REQUEST_GAP_MS
@@ -56,4 +83,5 @@ class CumminsGeneratorOptionsFlow(config_entries.OptionsFlow):
                     vol.Coerce(int), vol.Range(min=0, max=10000)
                 ),
             }),
+            errors=errors,
         )

--- a/custom_components/cummins_generator/strings.json
+++ b/custom_components/cummins_generator/strings.json
@@ -29,6 +29,10 @@
           "min_request_gap_ms": "Minimum delay between requests (ms, default 500)"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to generator",
+      "invalid_auth": "Invalid authentication"
     }
   }
 }

--- a/custom_components/cummins_generator/strings.json
+++ b/custom_components/cummins_generator/strings.json
@@ -23,8 +23,9 @@
     "step": {
       "init": {
         "title": "Cummins Generator options",
-        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; this setting adds a minimum delay between them.",
+        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; the delay setting adds a minimum gap between them.",
         "data": {
+          "password": "Password",
           "min_request_gap_ms": "Minimum delay between requests (ms, default 500)"
         }
       }

--- a/custom_components/cummins_generator/translations/en.json
+++ b/custom_components/cummins_generator/translations/en.json
@@ -29,6 +29,10 @@
           "min_request_gap_ms": "Minimum delay between requests (ms, default 500)"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to generator",
+      "invalid_auth": "Invalid authentication"
     }
   }
 }

--- a/custom_components/cummins_generator/translations/en.json
+++ b/custom_components/cummins_generator/translations/en.json
@@ -23,8 +23,9 @@
     "step": {
       "init": {
         "title": "Cummins Generator options",
-        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; this setting adds a minimum delay between them.",
+        "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; the delay setting adds a minimum gap between them.",
         "data": {
+          "password": "Password",
           "min_request_gap_ms": "Minimum delay between requests (ms, default 500)"
         }
       }


### PR DESCRIPTION
Closes #33.

## Summary
- Add the generator password as an editable field in the options flow (alongside the existing minimum-request-gap setting). Defaults to the currently stored password.
- On change, persist to `entry.data` via `async_update_entry` and apply live to the running `GeneratorClient` through a new `update_password()` method — same pattern as `update_min_gap()`, no reload needed.
- Validate the password up-front in both the initial-setup and options flows by hitting `/index_data.html`. A 401 renders an inline "Invalid authentication" error, network failures render "Failed to connect", and neither path mutates the stored password.

## Test plan
- [x] Settings → Devices & Services → Cummins Generator → Configure — confirm both Password and delay fields render, and Password is prefilled with the current value.
- [x] Change only the delay, save, verify sensors still update (password-unchanged path skips the probe).
- [x] Change the password to something wrong, save — form re-renders with "Invalid authentication", stored password is unchanged, sensors keep updating.
- [x] Turn the generator off (or block it at the network) and submit any password change — form re-renders with "Failed to connect", stored password is unchanged.
- [x] Change the password to the correct new value — form closes cleanly and sensors keep updating without an HA restart.
- [ ] Fresh install: initial setup with the wrong password now shows "Invalid authentication" inline instead of failing setup with `ConfigEntryNotReady`.