### PR TITLE
Add generator-vs-HA time-drift sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Home Assistant custom integration for monitoring and controlling Cummins stand
 - **Frequency** - Output frequency in Hz
 - **Engine Hours** - Total runtime hours
 - **Load Line 1 & 2** - Current load percentages
-- **Time Drift** - Signed seconds by which the generator clock leads Home Assistant's clock (rounded to the minute)
+- **Time Drift** - Signed seconds representing the difference between the generator clock and Home Assistant's clock (rounded to the minute)
 
 ### Binary Sensors
 - **Utility Present** - Utility power availability

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Home Assistant custom integration for monitoring and controlling Cummins stand
 - **Frequency** - Output frequency in Hz
 - **Engine Hours** - Total runtime hours
 - **Load Line 1 & 2** - Current load percentages
-- **Time Drift** - Signed seconds representing the difference between the generator clock and Home Assistant's clock (rounded to the minute)
+- **Time Drift** - Signed minutes representing the difference between the generator clock and Home Assistant's clock
 
 ### Binary Sensors
 - **Utility Present** - Utility power availability

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Home Assistant custom integration for monitoring and controlling Cummins stand
 - **Frequency** - Output frequency in Hz
 - **Engine Hours** - Total runtime hours
 - **Load Line 1 & 2** - Current load percentages
+- **Time Drift** - Signed seconds by which the generator clock leads Home Assistant's clock (rounded to the minute)
 
 ### Binary Sensors
 - **Utility Present** - Utility power availability

--- a/custom_components/cummins_generator/datetime.py
+++ b/custom_components/cummins_generator/datetime.py
@@ -5,7 +5,10 @@ from datetime import datetime, timedelta
 from homeassistant.components.datetime import DateTimeEntity
 from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
 from homeassistant.helpers.entity import DeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
@@ -16,6 +19,14 @@ DOMAIN = "cummins_generator"
 def signal_time_updated(host: str) -> str:
     """Dispatcher signal fired when a write pushes a fresh value."""
     return f"cummins_generator_datetime_updated_{host}"
+
+
+def signal_time_read(host: str) -> str:
+    """Dispatcher signal fired after each successful read from the generator.
+
+    Payload is (generator_utc, ha_utc_at_read).
+    """
+    return f"cummins_generator_datetime_read_{host}"
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -76,9 +87,18 @@ class CumminsGeneratorDateTime(DateTimeEntity):
         """Fetch current date/time from generator."""
         try:
             html = await self.client.get("/timedate.html")
-            self._value = self._parse_datetime(html)
         except Exception as err:
             _LOGGER.error("Error fetching generator time: %s", err)
+            return
+        parsed = self._parse_datetime(html)
+        if parsed is None:
+            return
+        ha_now = dt_util.utcnow()
+        self._value = parsed
+        if self.hass is not None:
+            async_dispatcher_send(
+                self.hass, signal_time_read(self.client.host), parsed, ha_now
+            )
 
     def _parse_datetime(self, html):
         """Parse date/time from timedate.html."""

--- a/custom_components/cummins_generator/datetime.py
+++ b/custom_components/cummins_generator/datetime.py
@@ -82,6 +82,12 @@ class CumminsGeneratorDateTime(DateTimeEntity):
         """Adopt a value freshly written to the generator, no re-read needed."""
         self._value = value.replace(second=0, microsecond=0)
         self.async_write_ha_state()
+        async_dispatcher_send(
+            self.hass,
+            signal_time_read(self.client.host),
+            self._value,
+            dt_util.utcnow(),
+        )
 
     async def async_update(self):
         """Fetch current date/time from generator."""

--- a/custom_components/cummins_generator/sensor.py
+++ b/custom_components/cummins_generator/sensor.py
@@ -1,7 +1,9 @@
 """Cummins Generator sensor platform."""
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -9,13 +11,17 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.helpers.entity import DeviceInfo
 
+from .datetime import signal_time_read
+
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=30)
 DOMAIN = "cummins_generator"
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Cummins Generator sensors."""
-    coordinator = hass.data["cummins_generator"][config_entry.entry_id]["coordinator"]
+    data = hass.data["cummins_generator"][config_entry.entry_id]
+    coordinator = data["coordinator"]
+    client = data["client"]
 
     sensors = [
         CumminsGeneratorSensor(coordinator, "status", "Status"),
@@ -25,6 +31,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         CumminsGeneratorSensor(coordinator, "engine_hours", "Engine Hours", "h"),
         CumminsGeneratorSensor(coordinator, "load_1", "Load Line 1", "%"),
         CumminsGeneratorSensor(coordinator, "load_2", "Load Line 2", "%"),
+        CumminsGeneratorTimeDriftSensor(client.host),
     ]
     async_add_entities(sensors)
 
@@ -112,3 +119,50 @@ class CumminsGeneratorSensor(CoordinatorEntity, SensorEntity):
     def native_unit_of_measurement(self):
         """Return the unit of measurement."""
         return self._unit
+
+
+class CumminsGeneratorTimeDriftSensor(SensorEntity):
+    """Signed seconds by which the generator clock leads HA's clock.
+
+    The generator reports date/time only to minute precision, so this
+    reading quantizes to the nearest minute; sub-minute values reflect
+    that rounding more than real drift.
+    """
+
+    _attr_should_poll = False
+    _attr_native_unit_of_measurement = "s"
+    _attr_suggested_display_precision = 0
+
+    def __init__(self, host):
+        self._host = host
+        self._attr_unique_id = f"{host}_time_drift"
+        self._value: float | None = None
+
+    @property
+    def name(self):
+        return "Cummins Generator Time Drift"
+
+    @property
+    def native_value(self):
+        return self._value
+
+    @property
+    def device_info(self):
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._host)},
+            name="Cummins Generator",
+            manufacturer="Cummins",
+            model="Generator",
+        )
+
+    async def async_added_to_hass(self) -> None:
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, signal_time_read(self._host), self._handle_read
+            )
+        )
+
+    @callback
+    def _handle_read(self, generator_utc: datetime, ha_utc: datetime) -> None:
+        self._value = (generator_utc - ha_utc).total_seconds()
+        self.async_write_ha_state()

--- a/custom_components/cummins_generator/sensor.py
+++ b/custom_components/cummins_generator/sensor.py
@@ -164,5 +164,6 @@ class CumminsGeneratorTimeDriftSensor(SensorEntity):
 
     @callback
     def _handle_read(self, generator_utc: datetime, ha_utc: datetime) -> None:
-        self._value = round((generator_utc - ha_utc).total_seconds() / 60)
+        ha_minute = ha_utc.replace(second=0, microsecond=0)
+        self._value = round((generator_utc - ha_minute).total_seconds() / 60)
         self.async_write_ha_state()

--- a/custom_components/cummins_generator/sensor.py
+++ b/custom_components/cummins_generator/sensor.py
@@ -122,21 +122,21 @@ class CumminsGeneratorSensor(CoordinatorEntity, SensorEntity):
 
 
 class CumminsGeneratorTimeDriftSensor(SensorEntity):
-    """Signed seconds by which the generator clock leads HA's clock.
+    """Signed minutes representing the difference between the generator
+    clock and HA's clock.
 
-    The generator reports date/time only to minute precision, so this
-    reading quantizes to the nearest minute; sub-minute values reflect
-    that rounding more than real drift.
+    The generator only reports date/time to minute precision, so the
+    raw delta is rounded to the nearest whole minute.
     """
 
     _attr_should_poll = False
-    _attr_native_unit_of_measurement = "s"
+    _attr_native_unit_of_measurement = "min"
     _attr_suggested_display_precision = 0
 
     def __init__(self, host):
         self._host = host
         self._attr_unique_id = f"{host}_time_drift"
-        self._value: float | None = None
+        self._value: int | None = None
 
     @property
     def name(self):
@@ -164,5 +164,5 @@ class CumminsGeneratorTimeDriftSensor(SensorEntity):
 
     @callback
     def _handle_read(self, generator_utc: datetime, ha_utc: datetime) -> None:
-        self._value = (generator_utc - ha_utc).total_seconds()
+        self._value = round((generator_utc - ha_utc).total_seconds() / 60)
         self.async_write_ha_state()


### PR DESCRIPTION
Closes #35.

## Summary
- New `sensor.cummins_generator_time_drift`: signed **minutes** representing the difference between the generator's reported wall clock and HA's clock at the moment of the read (positive → generator ahead of HA).
- Piggybacks on the existing hourly `/timedate.html` read via a new dispatcher signal (`signal_time_read`) — no extra HTTP traffic, and the drift is always computed from a single timestamp pair (no risk of comparing generator time and HA time captured minutes apart).
- Write paths (Sync Time button and `async_set_value`) also fan out through the same signal, so the drift refreshes immediately when the clock is written — no hour-long wait for the next poll tick.
- Documented in the README's sensor list.

## Notes
- The generator only reports to minute precision. Both sides of the subtraction are floored to the minute before rounding, so identical clocks read `0`, not the `-1` you'd get from subtracting minute-truncated generator time from a sub-minute-precise HA time.
- Left the sensor without a `device_class`, since `DURATION` implies a non-negative quantity in HA.

## Test plan
- [x] Full HA restart (custom components don't reimport on Reload). Confirm `sensor.cummins_generator_time_drift` appears under the Cummins Generator device.
- [x] On startup, the datetime entity fetches once via `update_before_add`; the drift sensor should populate at the same time.
- [x] Press Sync Time — drift should read `0` immediately (not `-1`), no hourly wait.
- [x] Set the generator's clock forward N minutes via the datetime entity or Sync Time after skewing HA's clock, and verify the drift reflects it.
- [x] Compare `sensor.cummins_generator_time_drift` state against manual math from `datetime.cummins_generator_date_time` vs `now()` — should match to the minute.