### PR TITLE
Stop double-polling the generator

### DIFF
--- a/custom_components/cummins_generator/binary_sensor.py
+++ b/custom_components/cummins_generator/binary_sensor.py
@@ -1,6 +1,7 @@
 """Cummins Generator binary sensor platform."""
 from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 DOMAIN = "cummins_generator"
 
@@ -17,12 +18,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     ]
     async_add_entities(binary_sensors)
 
-class CumminsGeneratorBinarySensor(BinarySensorEntity):
+class CumminsGeneratorBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Representation of a Cummins Generator binary sensor."""
 
     def __init__(self, coordinator, sensor_type, name, mask):
         """Initialize the binary sensor."""
-        self.coordinator = coordinator
+        super().__init__(coordinator)
         self.sensor_type = sensor_type
         self._name = name
         self.mask = mask
@@ -56,12 +57,3 @@ class CumminsGeneratorBinarySensor(BinarySensorEntity):
             return False
         lcd_status = self.coordinator.data.get("lcd_status", 0)
         return bool(lcd_status & self.mask)
-
-    @property
-    def available(self):
-        """Return if entity is available."""
-        return self.coordinator.last_update_success
-
-    async def async_update(self):
-        """Update the entity."""
-        await self.coordinator.async_request_refresh()

--- a/custom_components/cummins_generator/select.py
+++ b/custom_components/cummins_generator/select.py
@@ -2,7 +2,11 @@
 import logging
 from homeassistant.components.select import SelectEntity
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
 from datetime import timedelta
 
 _LOGGER = logging.getLogger(__name__)
@@ -102,12 +106,12 @@ class CumminsLoadCoordinator(DataUpdateCoordinator):
             "exercise_minute": minute if minute in min_options else "00",
         }
 
-class CumminsGeneratorSelect(SelectEntity):
+class CumminsGeneratorSelect(CoordinatorEntity, SelectEntity):
     """Representation of a Cummins Generator select entity."""
 
     def __init__(self, coordinator, select_type, name, options):
         """Initialize the select entity."""
-        self.coordinator = coordinator
+        super().__init__(coordinator)
         self.select_type = select_type
         self._name = name
         self._attr_options = options
@@ -134,11 +138,6 @@ class CumminsGeneratorSelect(SelectEntity):
         if not self.coordinator.data:
             return None
         return self.coordinator.data.get(self.select_type)
-
-    @property
-    def available(self):
-        """Return if entity is available."""
-        return self.coordinator.last_update_success
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -169,7 +168,3 @@ class CumminsGeneratorSelect(SelectEntity):
             await self.coordinator.async_request_refresh()
         except Exception as err:
             _LOGGER.error("Error setting %s: %s", self._name, err)
-
-    async def async_update(self):
-        """Update the entity."""
-        await self.coordinator.async_request_refresh()

--- a/custom_components/cummins_generator/sensor.py
+++ b/custom_components/cummins_generator/sensor.py
@@ -2,7 +2,11 @@
 import logging
 from datetime import timedelta
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
 from homeassistant.helpers.entity import DeviceInfo
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,12 +69,12 @@ class CumminsGeneratorCoordinator(DataUpdateCoordinator):
             "lcd_status": int(lines[13]),
         }
 
-class CumminsGeneratorSensor(SensorEntity):
+class CumminsGeneratorSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Cummins Generator sensor."""
 
     def __init__(self, coordinator, sensor_type, name, unit=None):
         """Initialize the sensor."""
-        self.coordinator = coordinator
+        super().__init__(coordinator)
         self.sensor_type = sensor_type
         self._name = name
         self._unit = unit
@@ -100,20 +104,11 @@ class CumminsGeneratorSensor(SensorEntity):
         )
 
     @property
-    def state(self):
-        """Return the state of the sensor."""
+    def native_value(self):
+        """Return the current sensor value."""
         return self.coordinator.data.get(self.sensor_type)
 
     @property
     def native_unit_of_measurement(self):
         """Return the unit of measurement."""
         return self._unit
-
-    @property
-    def available(self):
-        """Return if entity is available."""
-        return self.coordinator.last_update_success
-
-    async def async_update(self):
-        """Update the entity."""
-        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## Root cause
Coordinator-backed entities (sensor, binary_sensor, select) all defined `async_update` that called `coordinator.async_request_refresh()`, but *also* inherited the default `should_poll=True`. So on top of each `DataUpdateCoordinator`'s own 30 s timer, HA was polling every entity every 30 s and each poll requested another refresh. The two schedules ran out of phase, doubling the effective request rate.

## Evidence
A 2-minute `tcpdump` on the HA host against the generator IP showed:
```
   8 GET /exercise.html
   8 GET /index_data.html
   8 GET /loads.html
   8 GET /loads_data.html
```
That's ~1 request every ~15 s per endpoint, not the ~30 s the coordinators are configured for.

## Fix
Switch the three entity classes to `CoordinatorEntity`. That base class:
- subscribes to coordinator push updates instead of polling,
- sets `should_poll=False`,
- exposes `available` from `last_update_success`.

Also drops the now-redundant hand-rolled `available` and `async_update` methods on all three, and switches `CumminsGeneratorSensor` from `state` to `native_value` (the SensorEntity-native accessor that respects device-class formatting).

Now the coordinator's 30 s timer is the sole request source, cutting load on the generator's embedded controller in half.

## Test plan
- [x] Full HA restart (custom components don't reimport on Reload).
- [x] Re-run `sudo tcpdump -i any 'host <generator_ip> and tcp port 80'` for 2 min: expect ~4 hits per endpoint (was 8).
- [x] Sensors, binary sensors, and select entities still populate on restart and continue updating on the 30 s cadence.
- [x] Changing a select option still triggers an immediate refresh (`async_request_refresh` after write is unchanged).
- [x] Datetime and time-drift behavior is unaffected (those don't use this coordinator).