### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/custom_components/cummins_generator/manifest.json
+++ b/custom_components/cummins_generator/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mswilson/cummins-hass-integration/issues",
   "requirements": ["aiohttp"],
-  "version": "0.1.0"
+  "version": "0.2.0"
 }


### PR DESCRIPTION
Prepares the 0.2.0 release. Only bumps \`custom_components/cummins_generator/manifest.json\` — everything else has already landed on main.

## What ships in 0.2.0

### Features
- **Time-drift sensor** (#36, closes #35): `sensor.cummins_generator_time_drift` reports signed minutes representing the difference between the generator clock and HA's clock. Piggybacks on the existing hourly `/timedate.html` read (no extra HTTP traffic) and refreshes immediately on write paths.
- **Editable password** (#34, closes #33): password is now available in the options flow. Both the initial-setup and options flows validate the password up-front against the generator; a bad password renders inline instead of failing setup or silently going Unavailable.
- **Better Sync Time** (#39, closes #38): sleeps until the next \`:00\` wall-clock second before writing, keeping the second-level offset near zero. The button also now refreshes the datetime entity and drift sensor immediately (no hourly wait).

### Fixes
- **Stop double-polling the generator** (#37): coordinator-backed entities were both polled every 30 s by HA *and* triggering their own refresh, doubling request traffic. Migrated to `CoordinatorEntity`, restoring the documented cadence and cutting load on the embedded controller in half.
- **Datetime entity now populates at setup** (#31): was starting Unknown for up to an hour after HA restart; fixed by passing \`update_before_add=True\` and lowering the datetime poll cadence to hourly.

## Test plan
- [ ] Merge PR, tag \`v0.2.0\` on main, cut a GitHub Release with notes.
- [ ] Restart HA and verify \`manifest.json\` shows 0.2.0 (Settings → Devices & Services → Cummins Generator → three-dot menu → System information).
- [ ] Confirm HACS picks up the new tag and offers the upgrade.