### PR TITLE
Reshape polling to avoid wedging the generator's TCP stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ The integration polls the generator's web interface on a per-platform cadence:
 |---|---|---|
 | Sensors (status, voltages, frequency, engine hours, loads) | 30 s | `/index_data.html` |
 | Binary sensors (utility, running, standby, action required) | 30 s | shares the sensor poll |
-| Load & exercise selects | 30 s | `/loads_data.html`, `/exercise.html` |
+| Load & exercise selects | 100 s per endpoint, rotating (~5 min per endpoint) | `/loads_data.html`, `/loads.html`, `/exercise.html` |
 | Date/time entity | 1 h | `/timedate.html` |
 | Buttons | on demand | control endpoints only |
 
-Requests are additionally spaced out by a configurable minimum request gap (default 500 ms) to avoid overwhelming the generator's web interface.
+Requests are additionally spaced out by a configurable minimum request gap (default 2000 ms) to avoid overwhelming the generator's embedded network stack. For the reasoning — including source-level analysis of the InterNiche 2.0 TCP/IP stack — see [docs/generator-network-stack.md](docs/generator-network-stack.md).
 
 ## Installation
 

--- a/custom_components/cummins_generator/client.py
+++ b/custom_components/cummins_generator/client.py
@@ -36,9 +36,14 @@ async def validate_credentials(hass, host: str, password: str) -> None:
     ).decode("ascii")
     url = f"http://{host}/index_data.html"
     timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT_SECONDS)
+    headers = {
+        "Authorization": auth_header,
+        "Connection": "close",
+        "Accept-Encoding": "identity",
+    }
     try:
         async with session.get(
-            url, headers={"Authorization": auth_header}, timeout=timeout
+            url, headers=headers, timeout=timeout
         ) as response:
             if response.status == 401:
                 raise InvalidAuth
@@ -74,13 +79,24 @@ class GeneratorClient:
 
     async def get(self, path: str) -> str:
         """Issue a serialized, rate-limited GET and return the body text."""
-        headers = {"Authorization": self._auth_header}
+        # Explicit close + identity encoding + no compression tokens the
+        # generator's InterNiche 2.0 stack may not recognize. See
+        # docs/generator-network-stack.md for the reasoning.
+        headers = {
+            "Authorization": self._auth_header,
+            "Connection": "close",
+            "Accept-Encoding": "identity",
+        }
         timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT_SECONDS)
         url = f"http://{self.host}{path}"
 
         async with self._lock:
             if self._session is None:
-                self._session = aiohttp.ClientSession()
+                # force_close=True prevents aiohttp from pooling a
+                # connection the server is going to FIN anyway.
+                self._session = aiohttp.ClientSession(
+                    connector=aiohttp.TCPConnector(force_close=True)
+                )
 
             now = self._hass.loop.time()
             wait = self._min_gap - (now - self._last_request_end)

--- a/custom_components/cummins_generator/const.py
+++ b/custom_components/cummins_generator/const.py
@@ -1,4 +1,4 @@
 """Constants for the Cummins Generator integration."""
 
 CONF_MIN_REQUEST_GAP_MS = "min_request_gap_ms"
-DEFAULT_MIN_REQUEST_GAP_MS = 500
+DEFAULT_MIN_REQUEST_GAP_MS = 2000

--- a/custom_components/cummins_generator/select.py
+++ b/custom_components/cummins_generator/select.py
@@ -64,18 +64,14 @@ class CumminsLoadCoordinator(DataUpdateCoordinator):
         self._data.update(fresh)
         return dict(self._data)
 
-    async def refresh_endpoint(self, endpoint: str) -> None:
-        """Fetch a single endpoint immediately, e.g. after a write.
+    def apply_local_update(self, update: dict) -> None:
+        """Overwrite cached values without re-reading the generator.
 
-        Bypasses the round-robin cycle and merges the result into the
-        coordinator's data.
+        Used after a successful write when the generator's HTML would
+        otherwise still render a stale value for the next few seconds.
+        The next scheduled poll of that endpoint will re-verify.
         """
-        try:
-            fresh = await self._fetch_endpoint(endpoint)
-        except Exception as err:
-            _LOGGER.warning("Refresh of %s failed: %s", endpoint, err)
-            return
-        self._data.update(fresh)
+        self._data.update(update)
         self.async_set_updated_data(dict(self._data))
 
     async def _fetch_endpoint(self, endpoint: str) -> dict:
@@ -176,38 +172,40 @@ class CumminsGeneratorSelect(CoordinatorEntity, SelectEntity):
         return self.coordinator.data.get(self.select_type)
 
     async def async_select_option(self, option: str) -> None:
-        """Change the selected option."""
-        refresh_endpoint = "loads"
+        """Change the selected option.
+
+        After a successful write, we adopt the value locally rather
+        than re-reading. The generator's HTML endpoints render from
+        state that lags the write by a few seconds, so an immediate
+        read-back would clobber our new value with the old one. The
+        next scheduled poll of the endpoint (up to ~5 min later) will
+        re-verify and self-correct if the write didn't actually take.
+        """
         if self.select_type == "load_mode":
             value = "1" if option == "Manual" else "2"
             path = f"/wr_logical.cgi?@426={value}"
         elif self.select_type == "load_1":
             value = "3" if option == "Disconnected" else "4"
             path = f"/wr_logical.cgi?@426={value}"
-            refresh_endpoint = "loads_data"
         elif self.select_type == "load_2":
             value = "5" if option == "Disconnected" else "6"
             path = f"/wr_logical.cgi?@426={value}"
-            refresh_endpoint = "loads_data"
         elif self.select_type == "exercise_frequency":
             value = ["0", "1", "2", "3"][["Never", "Weekly", "Bimonthly", "Monthly"].index(option)]
             path = f"/wr_logical.cgi?@425={value}"
-            refresh_endpoint = "exercise"
         elif self.select_type == "exercise_day":
             value = str(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"].index(option))
             path = f"/wr_logical.cgi?@391={value}"
-            refresh_endpoint = "exercise"
         elif self.select_type == "exercise_hour":
             path = f"/wr_logical.cgi?@392={option}"
-            refresh_endpoint = "exercise"
         elif self.select_type == "exercise_minute":
             path = f"/wr_logical.cgi?@393={option}"
-            refresh_endpoint = "exercise"
         else:
             return
 
         try:
             await self.coordinator.client.get(path)
-            await self.coordinator.refresh_endpoint(refresh_endpoint)
         except Exception as err:
             _LOGGER.error("Error setting %s: %s", self._name, err)
+            return
+        self.coordinator.apply_local_update({self.select_type: option})

--- a/custom_components/cummins_generator/select.py
+++ b/custom_components/cummins_generator/select.py
@@ -11,7 +11,11 @@ from datetime import timedelta
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = "cummins_generator"
-SCAN_INTERVAL = timedelta(seconds=30)
+# One endpoint per tick; three endpoints -> ~5 minute refresh per endpoint.
+# Keeps total request rate to the generator well below what causes the
+# InterNiche 2.0 stack to run out of packet buffers. See
+# docs/generator-network-stack.md.
+SCAN_INTERVAL = timedelta(seconds=100)
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Cummins Generator select entities."""
@@ -31,35 +35,67 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(selects)
 
 class CumminsLoadCoordinator(DataUpdateCoordinator):
-    """Data coordinator for Cummins Generator load management."""
+    """Data coordinator for Cummins Generator load management.
+
+    Each tick fetches a single endpoint, cycling through the three
+    endpoints below. On a `SCAN_INTERVAL` of 100 s, every endpoint sees
+    a fresh read every 5 minutes. The last-known values for the other
+    two endpoints are preserved so entities stay populated.
+    """
+
+    ENDPOINTS = ("loads_data", "loads", "exercise")
 
     def __init__(self, hass, client):
         """Initialize the coordinator."""
         super().__init__(hass, _LOGGER, name="Cummins Load", update_interval=SCAN_INTERVAL)
         self.client = client
         self.host = client.host
+        self._index = 0
+        self._data: dict = {}
 
     async def _async_update_data(self):
-        """Fetch load data from the generator."""
+        """Fetch one endpoint's worth of load data."""
+        endpoint = self.ENDPOINTS[self._index]
+        self._index = (self._index + 1) % len(self.ENDPOINTS)
         try:
-            load_html = await self.client.get("/loads.html")
-            load_data = self._parse_loads_html(load_html)
-
-            loads_data = await self.client.get("/loads_data.html")
-            lines = loads_data.strip().split('\n')
-            if len(lines) >= 3:
-                load_data.update({
-                    "load_1": "Connected" if int(lines[1]) == 0 else "Disconnected",
-                    "load_2": "Connected" if int(lines[2]) == 0 else "Disconnected",
-                })
-
-            exercise_html = await self.client.get("/exercise.html")
-            exercise_data = self._parse_exercise_html(exercise_html)
-
-            return {**load_data, **exercise_data}
-
+            fresh = await self._fetch_endpoint(endpoint)
         except Exception as err:
             raise UpdateFailed(f"Error communicating with generator: {err}")
+        self._data.update(fresh)
+        return dict(self._data)
+
+    async def refresh_endpoint(self, endpoint: str) -> None:
+        """Fetch a single endpoint immediately, e.g. after a write.
+
+        Bypasses the round-robin cycle and merges the result into the
+        coordinator's data.
+        """
+        try:
+            fresh = await self._fetch_endpoint(endpoint)
+        except Exception as err:
+            _LOGGER.warning("Refresh of %s failed: %s", endpoint, err)
+            return
+        self._data.update(fresh)
+        self.async_set_updated_data(dict(self._data))
+
+    async def _fetch_endpoint(self, endpoint: str) -> dict:
+        """Fetch one endpoint and return its parsed key/value pairs."""
+        if endpoint == "loads":
+            html = await self.client.get("/loads.html")
+            return self._parse_loads_html(html)
+        if endpoint == "loads_data":
+            body = await self.client.get("/loads_data.html")
+            lines = body.strip().split('\n')
+            if len(lines) < 3:
+                return {}
+            return {
+                "load_1": "Connected" if int(lines[1]) == 0 else "Disconnected",
+                "load_2": "Connected" if int(lines[2]) == 0 else "Disconnected",
+            }
+        if endpoint == "exercise":
+            html = await self.client.get("/exercise.html")
+            return self._parse_exercise_html(html)
+        return {}
 
     def _parse_loads_html(self, html):
         """Parse load management mode from HTML."""
@@ -141,30 +177,37 @@ class CumminsGeneratorSelect(CoordinatorEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
+        refresh_endpoint = "loads"
         if self.select_type == "load_mode":
             value = "1" if option == "Manual" else "2"
             path = f"/wr_logical.cgi?@426={value}"
         elif self.select_type == "load_1":
             value = "3" if option == "Disconnected" else "4"
             path = f"/wr_logical.cgi?@426={value}"
+            refresh_endpoint = "loads_data"
         elif self.select_type == "load_2":
             value = "5" if option == "Disconnected" else "6"
             path = f"/wr_logical.cgi?@426={value}"
+            refresh_endpoint = "loads_data"
         elif self.select_type == "exercise_frequency":
             value = ["0", "1", "2", "3"][["Never", "Weekly", "Bimonthly", "Monthly"].index(option)]
             path = f"/wr_logical.cgi?@425={value}"
+            refresh_endpoint = "exercise"
         elif self.select_type == "exercise_day":
             value = str(["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"].index(option))
             path = f"/wr_logical.cgi?@391={value}"
+            refresh_endpoint = "exercise"
         elif self.select_type == "exercise_hour":
             path = f"/wr_logical.cgi?@392={option}"
+            refresh_endpoint = "exercise"
         elif self.select_type == "exercise_minute":
             path = f"/wr_logical.cgi?@393={option}"
+            refresh_endpoint = "exercise"
         else:
             return
 
         try:
             await self.coordinator.client.get(path)
-            await self.coordinator.async_request_refresh()
+            await self.coordinator.refresh_endpoint(refresh_endpoint)
         except Exception as err:
             _LOGGER.error("Error setting %s: %s", self._name, err)

--- a/custom_components/cummins_generator/select.py
+++ b/custom_components/cummins_generator/select.py
@@ -22,7 +22,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     client = hass.data[DOMAIN][config_entry.entry_id]["client"]
     coordinator = CumminsLoadCoordinator(hass, client)
     await coordinator.async_config_entry_first_refresh()
-    
+    # Fill in the endpoints first_refresh didn't cover so all seven
+    # select entities come up with real values within seconds of HA
+    # start, rather than sitting Unknown until the round-robin gets
+    # to them (up to ~200 s later).
+    hass.async_create_task(coordinator.async_hydrate_remaining())
+
     selects = [
         CumminsGeneratorSelect(coordinator, "load_mode", "Load Mode", ["Manual", "Automatic"]),
         CumminsGeneratorSelect(coordinator, "load_1", "Load 1", ["Disconnected", "Connected"]),
@@ -63,6 +68,36 @@ class CumminsLoadCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"Error communicating with generator: {err}")
         self._data.update(fresh)
         return dict(self._data)
+
+    async def async_hydrate_remaining(self) -> None:
+        """Fetch the endpoints not yet covered by the first refresh.
+
+        Called once at setup after `async_config_entry_first_refresh`
+        so the remaining select entities populate within seconds of
+        HA start instead of waiting for the 100 s round-robin to reach
+        them. Requests still go through the client's serialized lock
+        and inter-request gap, so the burst is paced identically to
+        steady-state traffic and stays well inside the generator's
+        7-connection listen backlog. See
+        docs/generator-network-stack.md.
+
+        After first refresh the round-robin cursor sits at the *next*
+        endpoint to fetch, so `_index .. end .. 0 .. _index-1` covers
+        the two we still need, in the same order the round-robin
+        would have visited them.
+        """
+        rotated = self.ENDPOINTS[self._index:] + self.ENDPOINTS[:self._index]
+        for endpoint in rotated[:-1]:  # drop the one first-refresh handled
+            try:
+                fresh = await self._fetch_endpoint(endpoint)
+            except Exception as err:
+                _LOGGER.warning(
+                    "Startup hydration of %s failed; will retry on next tick: %s",
+                    endpoint, err,
+                )
+                continue
+            self._data.update(fresh)
+        self.async_set_updated_data(dict(self._data))
 
     def apply_local_update(self, update: dict) -> None:
         """Overwrite cached values without re-reading the generator.

--- a/custom_components/cummins_generator/strings.json
+++ b/custom_components/cummins_generator/strings.json
@@ -26,7 +26,7 @@
         "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; the delay setting adds a minimum gap between them.",
         "data": {
           "password": "Password",
-          "min_request_gap_ms": "Minimum delay between requests (ms, default 500)"
+          "min_request_gap_ms": "Minimum delay between requests (ms, default 2000)"
         }
       }
     },

--- a/custom_components/cummins_generator/translations/en.json
+++ b/custom_components/cummins_generator/translations/en.json
@@ -26,7 +26,7 @@
         "description": "The generator's embedded controller can lock up when it receives concurrent requests. Requests from this integration are already serialized; the delay setting adds a minimum gap between them.",
         "data": {
           "password": "Password",
-          "min_request_gap_ms": "Minimum delay between requests (ms, default 500)"
+          "min_request_gap_ms": "Minimum delay between requests (ms, default 2000)"
         }
       }
     },

--- a/docs/generator-network-stack.md
+++ b/docs/generator-network-stack.md
@@ -1,0 +1,224 @@
+# Notes on the Generator's Network Stack
+
+Field-collected notes on why the generator's embedded web server
+becomes unresponsive under otherwise reasonable HTTP polling, and the
+constraints that shape this integration's polling strategy. Written
+for developers who want to change how the integration talks to the
+generator without regressing stability.
+
+## TL;DR
+
+The generator runs **InterNiche Technologies TCP/IP 2.0** (circa
+2004). It has a small fixed pool of packet buffers, closes every
+HTTP connection with `Connection: Close`, and holds each closed TCB
+in `TIME_WAIT` for 60 seconds. Under our old polling pattern (four
+back-to-back requests every 30 s at 500 ms spacing) it took roughly
+20 minutes for the TCB / packet-buffer pool to deplete, at which
+point body sends silently fail (client sees a read timeout), then
+new SYNs are silently dropped (client sees connect-refuse), and the
+box wedges indefinitely. Recovery requires a power cycle.
+
+This is not a known CVE. It is straightforward resource
+under-provisioning in the 2.x stack combined with a client that was
+firing requests faster than the stack could recycle state.
+
+## The concrete hang, from a real capture
+
+On 2026-08-01 15:23:42, in the middle of a 20-minute run of clean
+30 s polling with debug logging on:
+
+1. `/exercise.html` fetch times out after 10 s. Traceback bottoms
+   in `aiohttp/streams.py: _wait("readany")` — the TCP connection
+   is established, the request was accepted, but the body never
+   arrived.
+2. Over the next ~8 minutes, some fetches succeed (slowly, 10–20 s),
+   most fail on body read.
+3. From roughly 15:32 onward, every request completes in ~3.6 s with
+   `CancelledError` raised inside `session.get()`'s context enter.
+   That's the signature of TCP connect never completing — no SYN/ACK.
+4. The controller stays wedged. An HA restart at 00:09 fails to
+   connect at all. First successful request is at 09:54 the next
+   morning after a power cycle.
+
+Two-phase failure — body-read timeouts, then connect refuse — is the
+key signal. It tells us the stack is running out of TX-side buffers
+first, then losing the ability to accept new connections at all.
+
+## What we found in the InterNiche 2.0 source
+
+We pulled a mirror of the InterNiche 2.0 tree (paths cited below are
+relative to that tree) and confirmed the resource constraints:
+
+| Resource | Value | Location |
+|---|---:|---|
+| Big packet buffers (1536 B) | 30 | `src/h/nios2/ipport.h` (`NUMBIGBUFS`) |
+| Little packet buffers (200 B) | 30 | `src/h/nios2/ipport.h` (`NUMLILBUFS`) |
+| mbuf pool (`mfreeq`) | `(30 + 30) × 2 + 3 = 123` | `src/tcp/nptcp.c` (see `tcpinit`) |
+| Listen backlog per socket | `SOMAXCONN = 5`, effective cap `⌊3 × qlimit / 2⌋ = 7` | `src/h/socket.h`, `src/tcp/socket2.c` (`sonewconn`) |
+| `TCPTV_MSL` (default) | 30 × `PR_SLOWHZ` = 15 s → `2 × MSL = 60 s` TIME_WAIT | `src/tcp/nptcp.c` |
+| `PR_SLOWHZ` | 2 ticks/s | `src/h/nptcp.h` |
+| FIN_WAIT_2 timeout | `tcp_maxidle = TCPTV_KEEPCNT × tcp_keepintvl = 8 × 75 × 0.5 s = 300 s` | `src/tcp/tcp_timr.c` |
+| Send/receive window per TCB | 8 KB / 8 KB | `src/tcp/tcp_usr.c` (`tcp_sendspace`, `tcp_recvspace`) |
+| PCB/TCB allocation | Heap via `calloc` + mutex (`npalloc`), no fixed pool | `src/nios2/targnios.c` |
+
+Two silent-failure paths matter for us:
+
+- `pk_alloc(len)` returns **NULL** when both `bigfreeq` and
+  `lilfreeq` are empty. Callers include `tcp_pktalloc()`, which is
+  used to build outgoing TCP segments. On NULL, the segment is
+  simply not built. The response body never leaves the box.
+  Comment from the stack's own source (paraphrasing
+  `src/tcp/tcp_out.c` around the `ENOBUFS` return): *"this can
+  happen when we run out of mbufs or pkt buffers … One solution is
+  to increase them."*
+- `sonewconn(head)` silently rejects new SYNs when
+  `head->so_qlen + head->so_q0len > 3 × head->so_qlimit / 2`. With
+  `SOMAXCONN = 5` that cap is 7. Rejection is a bare drop, not a
+  RST — the client just retransmits SYN until it gives up.
+
+Neither failure surfaces at the HTTP layer. The client sees only
+"timeout" or "connection refused."
+
+## How our old traffic pattern interacted with those limits
+
+Wire capture (see `tcpdump` output from an earlier debugging pass)
+shows every request cycle looks like:
+
+```
+client -> generator  SYN
+generator -> client  SYN/ACK
+client -> generator  ACK, GET /path HTTP/1.1  (with keep-alive implicit)
+generator -> client  HTTP/1.1 200 OK, Connection: Close, ... body ...
+generator -> client  FIN            <-- server initiates close
+client -> generator  ACK, FIN
+generator -> client  ACK
+```
+
+The generator responds with `Connection: Close` on every request and
+initiates the FIN. Consequences:
+
+- **The generator's TCB, not the client's, holds the state.** Its
+  TCB goes `ESTABLISHED → FIN_WAIT_1 → FIN_WAIT_2 → TIME_WAIT` and
+  stays in TIME_WAIT for **60 seconds**.
+- **HTTP keep-alive doesn't happen.** The server is closing anyway,
+  so aiohttp's connection pool never reuses anything for this host.
+  Each fetch is a fresh three-way handshake and a fresh
+  server-side TCB.
+
+Old polling pattern:
+
+- `sensor` coordinator: `/index_data.html` every 30 s (1 request)
+- `select` coordinator: `/loads.html` + `/loads_data.html` +
+  `/exercise.html` every 30 s (3 requests, 500 ms apart)
+
+Total: **4 requests per 30 s**, i.e. one every ~7.5 seconds on
+average. Each leaves one TCB in TIME_WAIT for 60 s.
+
+Steady-state TCB count on the generator: **~8** in TIME_WAIT. The
+listen-queue cap is **7**. We were living on the edge, and any
+hiccup — a slow response that delayed the FIN, a retransmit, a
+buffer temporarily held longer than expected — pushed us over.
+Once we started dropping SYNs, request timeouts stacked further
+buffer use, and the failure cascaded.
+
+## What we changed, and why
+
+### 1. Explicit connection close
+
+We now send `Connection: close` on every request and configure
+aiohttp with `TCPConnector(force_close=True)`. Rationale: the
+generator was already closing every connection, but aiohttp was
+silently maintaining a keep-alive pool that never got any reuse.
+Being explicit removes any ambiguity in the client's connection
+management and matches the server's actual behavior.
+
+### 2. `Accept-Encoding: identity`
+
+Old requests advertised `Accept-Encoding: gzip, deflate, br`. The
+`br` (Brotli) token postdates the InterNiche 2.0 stack by roughly a
+decade. `CVE-2021-27565` documents an infinite-loop trigger in the
+NicheStack HTTP server when it receives valid-but-unrecognized
+inputs (the reported example is `OPTIONS`). We haven't been able to
+prove that an unknown `Accept-Encoding` token trips a similar hook,
+but there's no upside to sending it — the generator has never
+gzipped a response — and there's a plausible-enough downside to
+sending it that we don't.
+
+### 3. Round-robin the load coordinator
+
+The `select` coordinator used to fetch three endpoints back-to-back
+every 30 s. Now it fetches **one** endpoint per tick with a 100 s
+interval, cycling through `loads_data.html → loads.html →
+exercise.html`. Each endpoint sees a fresh read every ~5 min.
+Writes still trigger a targeted refresh of the specific endpoint
+that changed, so responsive UI is preserved on user action.
+
+### 4. Default `min_request_gap_ms = 2000` (was 500)
+
+At the network-stack level, 500 ms is well inside every relevant
+timer (MSL, keep-interval, persist-min are all seconds). It only
+serialized aiohttp's own send order. Bumping to 2 s gives the
+stack time to complete the FIN handshake, drain TIME_WAIT of at
+least one entry, and reclaim its buffers between the times we do
+fire consecutive requests.
+
+The setting remains user-tunable through the options flow.
+
+### Result: steady-state pressure
+
+| Metric | Before | After |
+|---|---:|---:|
+| Requests per 30 s cycle | 4 | 1 (sensor) + ≤0.3 (load, 1 per 100 s) |
+| Total requests / minute | ~8 | ~2.6 |
+| TCBs in TIME_WAIT (steady) | ~8 | ~2.6 |
+| Listen-queue headroom (cap 7) | ~0 | ~4.4 |
+
+## Things we ruled out along the way
+
+- **INFRA:HALT (14 CVEs, Forescout 2021).** All 14 need a
+  malformed packet. Our traffic is well-formed HTTP GET. The
+  research targeted NicheStack 3.x/4.x; 2.0 wasn't audited.
+- **CVE-2021-27565 (unexpected valid HTTP method → infinite loop).**
+  Fires on the *first* offending request. We had 20+ minutes of
+  clean polling before symptoms. aiohttp's default headers on a
+  `GET` don't include `OPTIONS` or other unknown methods.
+- **Malicious traffic or auth issues.** No 401s, no config changes,
+  no writes from us in the pre-failure window.
+
+## If you're changing this code, keep these in mind
+
+- **Never fire concurrent requests to this generator.** The
+  `GeneratorClient` uses a single `asyncio.Lock` around request
+  send + wait so that only one request is ever in flight from us
+  at a time. Both coordinators depend on this; don't work around it.
+- **Assume every request holds a TCB on the generator for 60 s
+  after it completes.** Design your polling budget with that in
+  mind: at most `N` requests per 60 s, where `N` is comfortably
+  below 7.
+- **Assume `pk_alloc` failures are silent.** From your side, they
+  manifest as either a body-read timeout or (later) a
+  connection-refused. Log accordingly, but don't retry
+  aggressively — retrying while the generator is out of buffers
+  makes it worse.
+- **Prefer expanding an endpoint's polling interval over adding a
+  new endpoint.** If you must add a new endpoint, put it on the
+  load coordinator's round-robin so total request rate stays flat.
+- **Trust `Connection: close` on writes as much as on reads.** The
+  generator's response to `/wr_logical.cgi` still comes back with
+  `Connection: Close`. Don't attempt to reuse control connections
+  either.
+- **Do not enable HTTP compression** or advertise novel
+  `Accept-Encoding` tokens. `identity` only.
+- **Debugging hangs is expensive** — you'll need someone at the
+  physical unit to power-cycle it. Please add a `_LOGGER.debug()`
+  breadcrumb rather than shipping speculative retry logic.
+
+## Source references
+
+- InterNiche 2.0 source tree used for the buffer/limit numbers
+  cited above (private mirror).
+- Forescout, *INFRA:HALT: Discovering & Mitigating Large Scale OT
+  Vulnerabilities in Operational Technology*, 2021.
+- NVD, `CVE-2021-27565`.
+- Field capture and HA debug log from the 2026-08-01 15:23:42
+  failure (see git history around this document's introduction).

--- a/docs/generator-network-stack.md
+++ b/docs/generator-network-stack.md
@@ -194,7 +194,12 @@ The setting remains user-tunable through the options flow.
 - **Assume every request holds a TCB on the generator for 60 s
   after it completes.** Design your polling budget with that in
   mind: at most `N` requests per 60 s, where `N` is comfortably
-  below 7.
+  below 7. This budget applies to startup bursts too. The load
+  coordinator's startup hydration path (see
+  `async_hydrate_remaining` in `select.py`) walks the round-robin
+  once at setup to fill in all endpoints, but it goes through the
+  client's serialized lock and 2 s min-gap just like steady-state
+  traffic — no fan-out.
 - **Assume `pk_alloc` failures are silent.** From your side, they
   manifest as either a body-read timeout or (later) a
   connection-refused. Log accordingly, but don't retry


### PR DESCRIPTION
Closes #30.

## Summary
The generator's InterNiche 2.0 TCP/IP stack has a small fixed pool of packet buffers, holds every TCB in `TIME_WAIT` for 60 s, and silently drops SYNs past a 7-connection listen backlog. The old polling pattern (four back-to-back requests every 30 s) put steady-state pressure at ~8 TCBs held simultaneously — right at the cap. After ~20 minutes any hiccup would push us past it and the generator would wedge until power cycle.

Four changes, all in the direction of "talk less, and match the server's connection semantics":

1. **`Connection: close` + `TCPConnector(force_close=True)`** — the generator was already closing every connection; the aiohttp keep-alive pool was doing nothing useful for us. Being explicit removes ambiguity.
2. **`Accept-Encoding: identity`** — the old default advertised `br` (Brotli), which post-dates the stack by ~10 years. Given that this stack has a documented infinite-loop hook for unexpected-valid HTTP input (CVE-2021-27565), no upside to sending tokens it may not recognize.
3. **Load coordinator rotates one endpoint per 100 s tick** — cycles \`loads_data.html → loads.html → exercise.html\`. Each endpoint still refreshes every ~5 min. Writes adopt the just-written value locally instead of immediately re-reading (the generator's HTML lags the write); the next scheduled poll self-corrects if the write didn't take.
4. **`DEFAULT_MIN_REQUEST_GAP_MS` 500 → 2000** — 500 ms was well inside every relevant stack timer and didn't buy anything.

Steady-state request rate drops from ~8/min to ~2.6/min; TCBs held on the generator drop from ~8 to ~2.6, well under the 7-connection cap.

## Docs
Full write-up at [`docs/generator-network-stack.md`](../blob/mswilson/fix-controller-hang/docs/generator-network-stack.md): source-level cites from the InterNiche 2.0 tree (buffer sizes, TIME_WAIT constants, `sonewconn` cap), a walk-through of the 2026-08-01 15:23 incident from the debug log, and a "if you're changing this code" section pinning down the constraints future work needs to respect.

## Test plan
- [x] Merge, HACS-update on the test HA instance, full HA restart.
- [x] Confirm all seven select entities populate (may take up to 5 min after restart while the round-robin fills its cache).
- [x] Confirm `sensor.cummins_generator_status` still updates on the 30 s cadence.
- [x] Toggle a load select and verify the state reflects the change within a few seconds (targeted refresh, not the 5-min cycle).
- [x] Run \`tcpdump -i any 'host <gen_ip> and tcp port 80'\` for 5 min: expect ~13 requests total (10 sensor + 3 load endpoints), down from ~40. **Observed 14: 11 index_data + 1 each of loads_data, loads, exercise.**
- [ ] Leave it running for 24 h and watch for the hang to recur. If it does, we know something else is at play; if it doesn't, we've closed #30.

## Not in scope for this PR
- Increasing `REQUEST_TIMEOUT_SECONDS` past 10 s — worth revisiting if we still see slow-body responses under the new rate.
- Circuit-breaker after N consecutive failures. Deferred until we know whether the new rate alone fixes the class of failure.