### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/custom_components/cummins_generator/manifest.json
+++ b/custom_components/cummins_generator/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mswilson/cummins-hass-integration/issues",
   "requirements": ["aiohttp"],
-  "version": "0.2.0"
+  "version": "0.3.0"
 }


### PR DESCRIPTION
Prepares the 0.3.0 release. Only bumps \`custom_components/cummins_generator/manifest.json\`.

## What ships in 0.3.0

### Reliability
- **Stop wedging the generator's TCP stack** (#43, closes #30). The InterNiche 2.0 stack on this controller has ~30 packet buffers, holds every TCB in TIME_WAIT for 60 s, and silently drops SYNs past a 7-connection listen backlog. The old polling pattern (4 back-to-back requests every 30 s) sat at ~8 held TCBs — right at the cap — and any hiccup would push us over, wedging the generator until power cycle. Four changes together bring steady-state pressure to ~2.6 TCBs:
  - Send \`Connection: close\` + drive the aiohttp session through \`TCPConnector(force_close=True)\`.
  - Advertise \`Accept-Encoding: identity\` (was \`gzip, deflate, br\`).
  - Load coordinator rotates one endpoint per 100 s tick, cycling \`loads_data.html → loads.html → exercise.html\`.
  - Default \`min_request_gap_ms\` 500 → 2000.
  Verified with tcpdump: 40 → 14 requests per 5 min against the generator.
- **Select entities populate at startup instead of waiting up to 200 s** (#43). After \`async_config_entry_first_refresh\`, a background task walks the remaining two load endpoints in round-robin order at the same rate-limited pacing. All seven select entities come up populated within a few seconds of HA start.
- **Trust the write on select changes** (#43). The controller's HTML endpoints render from state that lags a write by a few seconds; reading back immediately would clobber a just-set value with the pre-write value. Load Mode and exercise selects now adopt the written value locally and let the scheduled round-robin re-verify.

### Docs
- **`docs/generator-network-stack.md`** (#43): source-level analysis of the InterNiche 2.0 TCP/IP stack — buffer counts, TIME_WAIT constants, `sonewconn` cap, the 2026-08-01 hang walkthrough, and a "if you're changing this code" section pinning down the constraints future work needs to respect.

## Test plan
- [ ] Merge PR, tag \`v0.3.0\` on the merge commit, cut a GitHub Release.
- [ ] Restart HA and verify \`manifest.json\` shows 0.3.0 (Settings → Devices & Services → Cummins Generator → three-dot menu → System information).
- [ ] Confirm HACS picks up the new tag and offers the upgrade.